### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,9 @@ class User {
 // src/Controller/Api/User.php
 public function actionUsers(): Response {
     $users = $repository->loadUsers();
-    $apiUsers = array_map([$this, '_convertUserToApiObject'], $users);
+    $apiUsers = array_map(function ($user) {
+        return $this->_convertUserToApiObject($user);
+    }, $users);
     return new Response(['data' => $apiUsers);
 }
 


### PR DESCRIPTION
Использование коллбэк-массивов в array_map противоречит основным принципам. Не на функцию в IDE не перейти, автоматический рефакторинг может сделаешь, а может нет. Такое надо отдельно запретить, конечно.